### PR TITLE
Ranks and Normalizes search results.

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -4,12 +4,17 @@ class Resource < ActiveRecord::Base
   include PgSearch
 
   CATEGORIES = %w{ exercises projects examples }
+  RANK_BY_UNIQUE_WORDS_IN_DOCUMENT = 8
+  RANK_BY_MEAN_HARMONIC_DISTANCE   = 4
+
+  RANKING = RANK_BY_MEAN_HARMONIC_DISTANCE + RANK_BY_UNIQUE_WORDS_IN_DOCUMENT
 
   pg_search_scope :search_in_readme,
-                  against: :readme,
+                  against:  { name: 'A', description: 'B', readme: 'C' },
                   using: {
                     tsearch: {
                       dictionary: "english",
+                      normalization: RANKING,
                       any_word: true,
                       highlight: {
                         start_sel: "<match>",

--- a/db/migrate/20150103002212_add_fields_to_resource.rb
+++ b/db/migrate/20150103002212_add_fields_to_resource.rb
@@ -1,0 +1,8 @@
+class AddFieldsToResource < ActiveRecord::Migration
+  def change
+    add_column :resources, :name, :string
+    add_column :resources, :description, :text
+    add_column :resources, :url, :string
+    add_column :resources, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150102221958) do
+ActiveRecord::Schema.define(version: 20150103002212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "resources", force: true do |t|
-    t.json     "manifest",   null: false
+    t.json     "manifest",    null: false
     t.text     "readme"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.string   "name"
+    t.text     "description"
+    t.string   "url"
+    t.string   "category"
   end
 
   create_table "search_results", force: true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,12 @@ resources = manifests.map do |manifest|
 
   readme_text = File.exists?(readme_file) ? File.read(readme_file) : nil
 
-  { manifest: manifest, readme: readme_text }
+  { name: manifest['name'],
+    url: manifest['url'],
+    description: manifest['description'],
+    category: manifest['category'],
+    manifest: manifest,
+    readme: readme_text }
 end
 
 Resource.create(resources)


### PR DESCRIPTION
I'm really not sure if this is the best way to do it, but I figured it
was worth a shot.

Some weirdness:
1. It highlights the name since it's being searched,
   not just the contents of the README.
2. We will have to re-seed the database after deploy to populate the
   name and description fields.

Here is what three example searches look like without the ranking/weighting:

![screen shot 2015-01-02 at 5 03 34 pm](https://cloud.githubusercontent.com/assets/50284/5601093/fa81ecea-92a1-11e4-8da8-e176ac29de0f.png)
![screen shot 2015-01-02 at 5 03 18 pm](https://cloud.githubusercontent.com/assets/50284/5601095/fabb3ef0-92a1-11e4-8359-3098ded2331c.png)
![screen shot 2015-01-02 at 5 02 57 pm](https://cloud.githubusercontent.com/assets/50284/5601094/fab9ac66-92a1-11e4-921e-cfc2d7bb017a.png)

And the same with the ranking:

![screen shot 2015-01-02 at 5 04 31 pm](https://cloud.githubusercontent.com/assets/50284/5601097/062d0aa2-92a2-11e4-8a14-1fc39983bf99.png)
![screen shot 2015-01-02 at 5 04 20 pm](https://cloud.githubusercontent.com/assets/50284/5601098/06311a7a-92a2-11e4-8339-4f03f1289feb.png)
![screen shot 2015-01-02 at 5 04 12 pm](https://cloud.githubusercontent.com/assets/50284/5601099/063da204-92a2-11e4-8c20-6acf5c25c154.png)

To be honest, I'm not sure it's an improvement or not.

/cc @openspectrum @jfarmer 

fixes #7 
