### PR TITLE
Enable CORS for *.codeunion.io

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem 'dotenv'
   gem 'foreman'
   gem 'yard'
+  gem 'rack-cors', :require => 'rack/cors'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,13 +58,13 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    foreman (0.76.0)
+    foreman (0.77.0)
       dotenv (~> 1.0.2)
       thor (~> 0.19.1)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
     hike (1.2.3)
-    i18n (0.7.0.beta1)
+    i18n (0.7.0)
     json (1.8.1)
     kgio (2.9.2)
     loofah (2.0.1)
@@ -72,14 +72,15 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
-    mini_portile (0.6.1)
+    mini_portile (0.6.2)
     minitest (5.5.0)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
-    pg (0.17.1)
+    pg (0.18.1)
     rack (1.6.0)
+    rack-cors (0.3.1)
     rack-test (0.6.2)
       rack (>= 1.0)
     rails (4.2.0.rc2)
@@ -107,7 +108,7 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
-    rails_serve_static_assets (0.0.2)
+    rails_serve_static_assets (0.0.3)
     rails_stdout_logging (0.0.3)
     railties (4.2.0.rc2)
       actionpack (= 4.2.0.rc2)
@@ -166,6 +167,7 @@ DEPENDENCIES
   nokogiri (= 1.6.5)
   pg
   pg_search!
+  rack-cors
   rails (= 4.2.0.rc2)
   rails-api
   rails_12factor

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,13 @@ module CodeunionApi
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.middleware.insert_before 0, "Rack::Cors", logger: (-> { Rails.logger }) do
+      allow do
+        # Serve all resources from any subdomain of codeunion.io
+        origins /^https?:\/\/(\w+\.)?codeunion\.io/
+        resource '*', headers: :any, methods: [:get]
+      end
+    end
   end
 end


### PR DESCRIPTION
Add [rack/cors](https://github.com/cyu/rack-cors) to enable resource sharing across all *.codeunion.io subdomains. This way we can AJAX into the API from any of our sites.
