### PR TITLE
Add code + rake tasks for creating manifests on our repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'nokogiri', '1.6.5'
 gem 'faraday',  '0.9.0'
 gem 'reverse_markdown', '0.6.0'
 
+gem 'octokit', '3.7.0'
+
 group :development do
   gem 'spring'
   gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.7)
     arel (6.0.0)
     builder (3.2.2)
     diff-lcs (1.2.5)
@@ -78,6 +79,8 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    octokit (3.7.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
     pg (0.18.1)
     rack (1.6.0)
     rack-cors (0.3.1)
@@ -135,6 +138,9 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     spring (1.2.0)
     sprockets (2.12.3)
       hike (~> 1.2)
@@ -165,6 +171,7 @@ DEPENDENCIES
   faraday (= 0.9.0)
   foreman
   nokogiri (= 1.6.5)
+  octokit (= 3.7.0)
   pg
   pg_search!
   rack-cors

--- a/lib/manifest_uploader.rb
+++ b/lib/manifest_uploader.rb
@@ -1,0 +1,93 @@
+require 'uri'
+require 'json'
+
+class ManifestUploader
+  # @param client [Octokit::Client]
+  #   An {https://github.com/octokit/octokit.rb Octokit::Client} instance
+  # @param manifest [Hash] A resource manifest
+  # @param options [Hash] An options +Hash+
+  # @option options [String] :manifest_filename
+  #   The manifest filename (defaults to +"manifest.json"+).
+  # @option options [String] :only_fields
+  #   An +Array+ of field names that will be retained in the manifest.  If
+  #   nothing is specificed, all fields will be retained.
+  def initialize(client, manifest, options = {})
+    @client   = client
+    @manifest = manifest
+    @options  = options
+  end
+
+  # Attempts to create the remote manifest if it doesn't exist and update the
+  # remote manifest if it differs from the supplied manifest.
+  def run
+    if !repo_manifest_exists?
+      puts "Creating manifest for #{manifest['name']}"
+      create_repo_manifest!
+    elsif repo_manifest_changed?
+      puts "Updating manifest for #{manifest['name']}"
+      update_repo_manifest!
+    else
+      puts "No changes to manifest for #{manifest['name']}, skipping..."
+    end
+  end
+
+  private
+
+  attr_reader :client, :manifest, :options
+
+  def filtered_manifest
+    if options.key?(:only_fields)
+      manifest.keep_if { |field, _| options[:only_fields].include?(field) }
+    else
+      manifest
+    end
+  end
+
+  def manifest_filename
+    @manifest_filename ||= options.fetch(:manifest_filename) { 'manifest.json' }
+  end
+
+  def manifest_content
+    JSON.pretty_generate(filtered_manifest)
+  end
+
+  def repo_name
+    URI.parse(manifest['url']).path[1..-1]
+  end
+
+  def repo_manifest
+    return @repo_manifest if @repo_manifest
+
+    begin
+      @repo_manifest = client.contents(repo_name, path: manifest_filename)
+    rescue Octokit::NotFound
+      nil
+    end
+  end
+
+  def repo_manifest_content
+    return unless repo_manifest_exists?
+
+    @repo_manifest_content ||= Base64.decode64(repo_manifest.content)
+  end
+
+  def repo_manifest_exists?
+    return @repo_manifest_exists unless @repo_manifest_exists.nil?
+    @repo_manifest_exists = !repo_manifest.nil?
+  end
+
+  def repo_manifest_changed?
+    manifest_content != repo_manifest_content
+  end
+
+  def update_repo_manifest!
+    sha = repo_manifest.sha
+    message = "Updated #{manifest_filename}"
+    client.update_contents(repo_name, manifest_filename, message, sha, manifest_content)
+  end
+
+  def create_repo_manifest!
+    message = "Added #{manifest_filename}"
+    client.create_contents(repo_name, manifest_filename, message, manifest_content)
+  end
+end

--- a/lib/tasks/manifests.rake
+++ b/lib/tasks/manifests.rake
@@ -1,0 +1,32 @@
+require 'dotenv/tasks'
+require 'manifest_uploader'
+
+DATA_DIR = File.expand_path('../../../db/init-data', __FILE__)
+
+namespace :manifests do
+  desc 'Creates manifest files on the appropriate GitHub repositories'
+  task :upload => [:environment, :dotenv] do
+    unless ENV.key?('GITHUB_ACCESS_TOKEN')
+      puts 'Please set GITHUB_ACCESS_TOKEN environment variable.'
+      exit 1
+    end
+
+    manifests_file = File.join(DATA_DIR, 'manifests.json')
+    manifests = JSON.load(File.read(manifests_file))
+
+    client = Octokit::Client.new({
+      access_token:  ENV['GITHUB_ACCESS_TOKEN'],
+      auto_paginate: true,
+      per_page:      100
+    })
+
+    repo_names = client.org_repos("codeunion").map(&:name)
+
+    options = { only_fields: %w(category tags notes) }
+
+    manifests.reject { |m| !repo_names.include?(m['name']) }.each do |manifest|
+      puts "Uploading manifest to #{manifest['name']}..."
+      ManifestUploader.new(client, manifest, options).run
+    end
+  end
+end


### PR DESCRIPTION
This is the first step towards automating the content available to our API.  This defines a rake tasks

``` shell-session
$ rake manifests:upload
```

that will read through each manifest in `db/init-data/manifests.json`, remove unnecessary fields, and create a `manifest.json` in the appropriate repository.  The "unnecessary" fields are those that one can derive directly from the GitHub repository, e.g., the repo name, description, etc.

After this, I will be submitting PRs to
1. Modify `ResourceLoader` to pull data from the remote `manifest.json` files rather than the local `manifests.json` file (this is ~90% done).
2. Implement GitHub webhooks so that repositories are added to the API results as soon as they're created and the manifests/readmes/etc. are updated immediately when we change them (this is ~50% done).
